### PR TITLE
fix <limits.h> include on ltable.c and lctype.h

### DIFF
--- a/lctype.h
+++ b/lctype.h
@@ -31,9 +31,7 @@
 
 #if !LUA_USE_CTYPE	/* { */
 
-#ifndef _KERNEL
 #include <limits.h>
-#endif /* _KERNEL */
 
 #include "llimits.h"
 

--- a/ltable.c
+++ b/ltable.c
@@ -23,10 +23,8 @@
 ** Hence even when the load factor reaches 100%, performance remains good.
 */
 
-#ifndef _KERNEL
 #include <math.h>
 #include <limits.h>
-#endif /* _KERNEL */
 
 #include "lua.h"
 


### PR DESCRIPTION
* leftover of 04aa740c9b8d26410ddd9bc47305076f79260579