### PR TITLE
fix <time.h> include on lstate.c

### DIFF
--- a/lstate.c
+++ b/lstate.c
@@ -57,9 +57,7 @@ typedef struct LG {
 */
 #if !defined(luai_makeseed)
 
-#ifndef _KERNEL
 #include <time.h>
-#endif /* _KERNEL */
 
 /*
 ** Compute an initial seed with some level of randomness.


### PR DESCRIPTION
* leftover of 04aa740c9b8d26410ddd9bc47305076f79260579